### PR TITLE
Update RakDotNet.IO and Use .NET Standard 2.1

### DIFF
--- a/InfectedRose.Builder.Behaviors/InfectedRose.Builder.Behaviors.csproj
+++ b/InfectedRose.Builder.Behaviors/InfectedRose.Builder.Behaviors.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InfectedRose.Builder/InfectedRose.Builder.csproj
+++ b/InfectedRose.Builder/InfectedRose.Builder.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InfectedRose.Core/HashMap.cs
+++ b/InfectedRose.Core/HashMap.cs
@@ -74,7 +74,7 @@ namespace InfectedRose.Core
 
             Marshal.StructureToPtr(obj, ptr, false);
             Marshal.Copy(ptr, buf, 0, size);
-            Marshal.FreeHGlobal(ptr)
+            Marshal.FreeHGlobal(ptr);
 
             return buf;
         }

--- a/InfectedRose.Core/InfectedRose.Core.csproj
+++ b/InfectedRose.Core/InfectedRose.Core.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="RakDotNet.IO" Version="1.0.0" />
+      <PackageReference Include="RakDotNet.IO" Version="1.0.1" />
     </ItemGroup>
 
 </Project>

--- a/InfectedRose.Database/InfectedRose.Database.csproj
+++ b/InfectedRose.Database/InfectedRose.Database.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
@@ -15,6 +14,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.2" />
+      <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
       <PackageReference Include="System.Data.SqlClient" Version="4.3.0" />
     </ItemGroup>
 

--- a/InfectedRose.Geometry/InfectedRose.Geometry.csproj
+++ b/InfectedRose.Geometry/InfectedRose.Geometry.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InfectedRose.Interface/InfectedRose.Interface.csproj
+++ b/InfectedRose.Interface/InfectedRose.Interface.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InfectedRose.Luz/InfectedRose.Luz.csproj
+++ b/InfectedRose.Luz/InfectedRose.Luz.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InfectedRose.Lvl/InfectedRose.Lvl.csproj
+++ b/InfectedRose.Lvl/InfectedRose.Lvl.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InfectedRose.Nif/InfectedRose.Nif.csproj
+++ b/InfectedRose.Nif/InfectedRose.Nif.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InfectedRose.Pipeline/InfectedRose.Pipeline.csproj
+++ b/InfectedRose.Pipeline/InfectedRose.Pipeline.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InfectedRose.Terrain/InfectedRose.Terrain.csproj
+++ b/InfectedRose.Terrain/InfectedRose.Terrain.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InfectedRose.Triggers/InfectedRose.Triggers.csproj
+++ b/InfectedRose.Triggers/InfectedRose.Triggers.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InfectedRose.Utilities/InfectedRose.Utilities.csproj
+++ b/InfectedRose.Utilities/InfectedRose.Utilities.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InfectedRose.World/InfectedRose.World.csproj
+++ b/InfectedRose.World/InfectedRose.World.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InfectedRose.World/WorldObject.cs
+++ b/InfectedRose.World/WorldObject.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Numerics;
 using System.Xml.Serialization;
+using InfectedRose.Core;
 using InfectedRose.Lvl;
 
 namespace InfectedRose.World


### PR DESCRIPTION
This pull request:
* Updates RakDotNet.IO to fix a memory leak found by yuwui.
* Fixes a missing semicolon in the fix for a similar memory leak to above in `HashMap.ToBytes`.
* Fixes a missing reference not covered by a previous refactor.
* Changes the RakDotNet project to use .NET Standard 2.1 instead of .NET Core 3.1.